### PR TITLE
fixed duplicate html id

### DIFF
--- a/modules/ui.js
+++ b/modules/ui.js
@@ -34,7 +34,7 @@ async function preloadTemplates() {
 export class AspectTrackerWindow extends Application {
   static get defaultOptions() {
     return mergeObject(super.defaultOptions, {
-      id: "fate-aspect-tracker-list",
+      id: "fate-aspect-tracker-app",
       template: "modules/fate-aspect-tracker/templates/aspect-list.hbs",
       width: 400,
       height: 300,


### PR DESCRIPTION
There is an HTML id attribute that is repeated both in the div (assigned by the handlebar template) and again the same one in the <ol> element.

Causes this when minimizing the window in Minimal UI module. Not a big deal but it would make me happy if this was fixed :) It is anyways not good to have duplicate IDs, even though it doesn't seem to affect anything else.

![image](https://user-images.githubusercontent.com/27952699/117512624-4011ec80-af90-11eb-97b4-0ed3e4126033.png)
